### PR TITLE
add option to disable sending html emails, only plaintext

### DIFF
--- a/classes/Form.php
+++ b/classes/Form.php
@@ -448,17 +448,21 @@ static function translate($key, $default, $replace = []) {
         }
 
         try {
-            
+
             $emailData = [
                 'from' => option('microman.formblock.from_email'),
                 'to' => explode(';', $recipient),
                 'subject' => $this->message('notify_subject'),
-                'attachments' => $this->attachments,
-                'body' => [
-                    'text' => Str::unhtml($body),
-                    'html' => $body
-                ]
+                'attachments' => $this->attachments
             ];
+
+            if (option('microman.formblock.disable_html')) {
+                $body_array = array('text' => Str::unhtml($body));
+            } else {
+                $body_array = array('text' => Str::unhtml($body), 'html' => $body);
+            }
+
+            $emailData["body"] = $body_array;
 
             if ($replyTo = $this->form_field('email', 'value')) {
                 $emailData['replyTo'] = $replyTo;

--- a/index.php
+++ b/index.php
@@ -24,6 +24,7 @@ Kirby::plugin('microman/formblock', [
         'default_language' => 'en',
         'disable_confirm' => false,
         'disable_notify' => false,
+        'disable_html' => false,
         'dynamic_validation' => true
     ],
     'templates' => [ 'formcontainer' => __DIR__ . "/templates/formcontainer.php" ],


### PR DESCRIPTION
Since i just had the case where a client needed the form to only send plaintext mails, i implemented an option based on the existing options to change between sending Plaintext AND Html Mails or only Plaintext Mails. I thought maybe this is interesting for other people too so i opened a pull request. I hope i did everything right and appreciate any heads-up or feedback.